### PR TITLE
Apply SqlException filter and Students error page

### DIFF
--- a/cu-part4-migrations/Filters/HandleSqlExceptionAttribute.cs
+++ b/cu-part4-migrations/Filters/HandleSqlExceptionAttribute.cs
@@ -1,0 +1,32 @@
+﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Filters;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using System.Data.SqlClient;
+
+namespace ContosoUniversity.Filters
+{
+    public class HandleSqlExceptionAttribute : ExceptionFilterAttribute
+    {
+        public override void OnException(ExceptionContext context)
+        {
+            var result = new ViewResult
+            {
+                ViewName = "Students/Error"
+            };
+
+            var exception = context.Exception;
+
+            // If the exception is of the exact type we're seeking, populate TempData with instructions for the user.
+            if (exception is SqlException && ((SqlException)exception).Number == 4060)
+            {
+                result.TempData = new TempDataDictionary(context.HttpContext, new SessionStateTempDataProvider())
+                {
+                    { "HandleSqlException", "Put your instructions here" }
+                };
+
+                context.Result = result;
+                context.ExceptionHandled = true;
+            }
+        }
+    }
+}

--- a/cu-part4-migrations/Pages/Students/Error.cshtml
+++ b/cu-part4-migrations/Pages/Students/Error.cshtml
@@ -1,0 +1,6 @@
+﻿@page
+@{
+    var message = TempData["HandleSqlException"] as string;
+}
+
+<h1>@message</h1>

--- a/cu-part4-migrations/Pages/Students/Index.cshtml.cs
+++ b/cu-part4-migrations/Pages/Students/Index.cshtml.cs
@@ -1,15 +1,14 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
-using Microsoft.AspNetCore.Mvc;
+using ContosoUniversity.Filters;
+using ContosoUniversity.Models;
 using Microsoft.AspNetCore.Mvc.RazorPages;
 using Microsoft.EntityFrameworkCore;
-using ContosoUniversity.Data;
-using ContosoUniversity.Models;
+using System;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace ContosoUniversity.Pages.Students
 {
+    [HandleSqlException]
     public class IndexModel : PageModel
     {
         private readonly ContosoUniversity.Data.SchoolContext _context;

--- a/cu-part4-migrations/Startup.cs
+++ b/cu-part4-migrations/Startup.cs
@@ -1,13 +1,9 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Threading.Tasks;
+using ContosoUniversity.Data;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
-using ContosoUniversity.Data;
-using Microsoft.EntityFrameworkCore;
 
 namespace ContosoUniversity
 {
@@ -25,7 +21,10 @@ namespace ContosoUniversity
             services.AddDbContext<SchoolContext>(options =>
               options.UseSqlServer(Configuration.GetConnectionString("DefaultConnection")));
 
-            services.AddMvc();
+            services.AddMvc()
+                .AddSessionStateTempDataProvider();
+
+            services.AddSession();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -42,6 +41,8 @@ namespace ContosoUniversity
             }
 
             app.UseStaticFiles();
+
+            app.UseSession();
 
             app.UseMvc(routes =>
             {


### PR DESCRIPTION
I created an exception filter and applied it to the Students Index page model by decorating it with the `[HandleSqlException]` attribute. The attribute must be applied at the class level, since Razor pages doesn't look at the method level for these filters.

The "Put your instructions here" placeholder text should be replaced with the instructions to be displayed to the user.